### PR TITLE
retry mounting the SD if failed

### DIFF
--- a/arm/main.c
+++ b/arm/main.c
@@ -44,12 +44,16 @@ void NORETURN _main(void* base) {
     irq_initialize();
     crypto_initialize();
     nand_initialize();
-    sdcard_init();
-    int res = ELM_Mount();
-    if (res) {
-        printf("SD Card mount error: %d\n", res);
-        panic(0);
-    }
+
+    int res;
+    do {
+        sdcard_init();
+        res = ELM_Mount();
+        if(res){
+            printf("SD Card mount error: %d\n", res);
+            udelay(1000000);
+        }
+    } while(res);
     smc_get_events();
     smc_set_odd_power(false);
 


### PR DESCRIPTION
Somtimes the SD card doesn't mount on the first try when loading from minute. This PR just retries the mount in a loop