### PR TITLE
Fix menu cleanup

### DIFF
--- a/arm-elfloader/stub.c
+++ b/arm-elfloader/stub.c
@@ -74,8 +74,8 @@ void *_main(void *base)
     elf = (u8*) base;
     elf += hdr->hdrsize + hdr->loadersize;
 
-    mem_setswap(1);
-    disable_boot0(1);
+    mem_setswap();
+    disable_boot0();
 
     entry = loadelf(elf);
     return entry;

--- a/arm/gui.c
+++ b/arm/gui.c
@@ -62,6 +62,9 @@ void gui_main() {
     m_main.option[0].active = (status & ISFSHAX_INSTALL_POSSIBLE) != 0;
     m_main.option[1].active = (status & ISFSHAX_REMOVAL_POSSIBLE) != 0;
 
+    if (!m_main.option[0].active)
+        m_main.selected = 3;
+
     /* enter main menu */
     menu_init(&m_main);
 }

--- a/arm/system/latte.h
+++ b/arm/system/latte.h
@@ -193,10 +193,6 @@
 #define LT_CLOCKGATE                  (LT_REG_BASE + 0x5E8)
 #define LT_SYSPLL_CFG                 (LT_REG_BASE + 0x5EC)
 
-#include "common/utils.h"
-static inline u32 latte_get_hw_version(void) {
-    return read32(LT_ASICREV_CCR);
-}
 
 #define LT_ABIF_CPLTL_OFFSET          (LT_REG_BASE + 0x620)
 #define LT_ABIF_CPLTL_DATA            (LT_REG_BASE + 0x624)

--- a/arm/system/latte.h
+++ b/arm/system/latte.h
@@ -192,8 +192,6 @@
 #define LT_RESETS_AHMN                (LT_REG_BASE + 0x5E4)
 #define LT_CLOCKGATE                  (LT_REG_BASE + 0x5E8)
 #define LT_SYSPLL_CFG                 (LT_REG_BASE + 0x5EC)
-
-
 #define LT_ABIF_CPLTL_OFFSET          (LT_REG_BASE + 0x620)
 #define LT_ABIF_CPLTL_DATA            (LT_REG_BASE + 0x624)
 #define LT_UNK628                     (LT_REG_BASE + 0x628)

--- a/arm/system/latte.h
+++ b/arm/system/latte.h
@@ -192,6 +192,12 @@
 #define LT_RESETS_AHMN                (LT_REG_BASE + 0x5E4)
 #define LT_CLOCKGATE                  (LT_REG_BASE + 0x5E8)
 #define LT_SYSPLL_CFG                 (LT_REG_BASE + 0x5EC)
+
+#include "common/utils.h"
+static inline u32 latte_get_hw_version(void) {
+    return read32(LT_ASICREV_CCR);
+}
+
 #define LT_ABIF_CPLTL_OFFSET          (LT_REG_BASE + 0x620)
 #define LT_ABIF_CPLTL_DATA            (LT_REG_BASE + 0x624)
 #define LT_UNK628                     (LT_REG_BASE + 0x628)

--- a/arm/video/gpu.c
+++ b/arm/video/gpu.c
@@ -17,8 +17,14 @@
 #include "gfx.h"
 #include "gpu_init.h"
 #include "pll.h"
-//#include "minini.h"
 #include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static u32 minini_get_uint(const char* value, u32 default_val) {
+    if (!value || !*value) return default_val;
+    return strtoul(value, NULL, 0);
+}
 
 void* gpu_tv_primary_surface_addr(void) {
     return (void*)(abif_gpu_read32(D1GRPH_PRIMARY_SURFACE_ADDRESS) & ~4);
@@ -52,7 +58,7 @@ void gpu_test(void) {
 }
 
 void gpu_switch_endianness(void) {
-    if (read16(MEM_GPU_ENDIANNESS) & 3 == 1)
+    if ((read16(MEM_GPU_ENDIANNESS) & 3) == 1)
         return;
 
     abif_gpu_write32(0x8020, 0xFFFFFFFF);
@@ -109,7 +115,6 @@ void gpu_do_ave_list(ave_init_entry_t* paEntries, u32 len) {
 
 int BSP_60XeDataStreaming_write(int val)
 {
-    int v4; // r6
     int v5; // r4
     unsigned int v6; // r4
     int v7; // r3
@@ -159,9 +164,8 @@ void gpu_display_init(void) {
     //gpu_switch_endianness();
     ave_i2c_init(400000, 0);
 
-    int needs_ave_init = 1;
     if (gpu_tv_primary_surface_addr()) {
-        needs_ave_init = 0;
+        // needs_ave_init = 0;
     }
 
     //pll_vi1_shutdown_alt();

--- a/arm/video/gpu.c
+++ b/arm/video/gpu.c
@@ -21,10 +21,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static u32 minini_get_uint(const char* value, u32 default_val) {
-    if (!value || !*value) return default_val;
-    return strtoul(value, NULL, 0);
-}
 
 void* gpu_tv_primary_surface_addr(void) {
     return (void*)(abif_gpu_read32(D1GRPH_PRIMARY_SURFACE_ADDRESS) & ~4);
@@ -37,10 +33,10 @@ void* gpu_drc_primary_surface_addr(void) {
 void gpu_dump_dc_regs()
 {
     for (int i = 0; i < 0x800; i += 4) {
-        printf("%04x: %08x\n", 0x6100 + i, abif_gpu_read32(0x6100 + i)); 
+        printf("%04x: %08lx\n", 0x6100 + i, abif_gpu_read32(0x6100 + i)); 
     }
     for (int i = 0; i < 0x800; i += 4) {
-        printf("%04x: %08x\n", 0x6900 + i, abif_gpu_read32(0x6900 + i)); 
+        printf("%04x: %08lx\n", 0x6900 + i, abif_gpu_read32(0x6900 + i)); 
     }
 }
 
@@ -113,33 +109,6 @@ void gpu_do_ave_list(ave_init_entry_t* paEntries, u32 len) {
     }
 }
 
-int BSP_60XeDataStreaming_write(int val)
-{
-    int v5; // r4
-    unsigned int v6; // r4
-    int v7; // r3
-    int v9; // [sp+0h] [bp-18h] BYREF
-
-    v9 = latte_get_hw_version();
-    if ( (v9 & 0xF000000) != 0 )
-    {
-        set32(LT_60XE_CFG, 0x1000);
-        v5 = read32(LT_60XE_CFG);
-        udelay(10);
-        v6 = v5 & ~8u;
-        if (val == 1)
-            v7 = 0;
-        else
-            v7 = 8;
-        write32(LT_60XE_CFG, (v7 | v6) & ~0x1000);
-    }
-    else
-    {
-        return 1024;
-    }
-    return 0;
-}
-
 int gpu_idk_upll()
 {
     u32 val_5E0 = read32(LT_RESETS);
@@ -184,8 +153,8 @@ void gpu_display_init(void) {
     gpu_do_init_list(gpu_init_entries_C, NUM_GPU_ENTRIES_C);
     gpu_do_ave_list(ave_init_entries_C, NUM_AVE_ENTRIES_C);
 
-    printf("GPU TV addr: %08x\n", gpu_tv_primary_surface_addr());
-    printf("GPU DRC addr: %08x\n", gpu_drc_primary_surface_addr());
+    printf("GPU TV addr: %p\n", gpu_tv_primary_surface_addr());
+    printf("GPU DRC addr: %p\n", gpu_drc_primary_surface_addr());
 
     abif_gpu_write32(D1GRPH_PRIMARY_SURFACE_ADDRESS, FB_TV_ADDR);
     abif_gpu_write32(D2GRPH_PRIMARY_SURFACE_ADDRESS, FB_DRC_ADDR);
@@ -227,54 +196,4 @@ void gpu_cleanup()
     // HACK: I can't get the endianness swap to work :/
     if ((read16(MEM_GPU_ENDIANNESS) & 3) != 2)
         abif_gpu_write32(D1GRPH_SWAP_CNTL, 0x220);
-}
-
-int clocks_ini(const char* key, const char* value)
-{
-    if(!strcmp(key, "gpu_clk_r")) {
-        u32 val_raw = minini_get_uint(value, 0);
-        spll_cfg_customclock.clkR = val_raw & 0xFFFF;
-        printf("gpu_clk_r=0x%04x\n", spll_cfg_customclock.clkR);
-    }
-    else if(!strcmp(key, "gpu_clk_f")) {
-        u32 val_raw = minini_get_uint(value, 0x285ED0);
-        spll_cfg_customclock.clkFMsb = val_raw >> 16;
-        spll_cfg_customclock.clkFLsb = (val_raw & 0xFFFF) >> 1;
-        printf("gpu_clk_f_msb=0x%04x\n", spll_cfg_customclock.clkFMsb);
-        printf("gpu_clk_f_lsb=0x%04x\n", spll_cfg_customclock.clkFLsb);
-    }
-    else if(!strcmp(key, "gpu_clk_s")) {
-        u32 val_raw = minini_get_uint(value, 0x1C2);
-        spll_cfg_customclock.clkS = val_raw & 0xFFFF;
-        printf("gpu_clk_s=0x%04x\n", spll_cfg_customclock.clkS);
-    }
-    else if(!strcmp(key, "gpu_clk_v")) {
-        u32 val_raw = minini_get_uint(value, 7);
-        spll_cfg_customclock.clkVMsb = val_raw >> 16;
-        spll_cfg_customclock.clkVLsb = val_raw & 0xFFFF;
-        printf("gpu_clk_v_msb=0x%04x\n", spll_cfg_customclock.clkVMsb);
-        printf("gpu_clk_v_lsb=0x%04x\n", spll_cfg_customclock.clkVLsb);
-    }
-    else if(!strcmp(key, "gpu_clk_o_0div")) {
-        u32 val_raw = minini_get_uint(value, 4);
-        spll_cfg_customclock.clkO0Div = val_raw & 0xFFFF;
-        printf("gpu_clk_o_0div=0x%04x\n", spll_cfg_customclock.clkO0Div);
-    }
-    else if(!strcmp(key, "gpu_clk_o_1div")) {
-        u32 val_raw = minini_get_uint(value, 4);
-        spll_cfg_customclock.clkO1Div = val_raw & 0xFFFF;
-        printf("gpu_clk_o_1div=0x%04x\n", spll_cfg_customclock.clkO1Div);
-    }
-    else if(!strcmp(key, "gpu_clk_o_2div")) {
-        u32 val_raw = minini_get_uint(value, 0);
-        spll_cfg_customclock.clkO2Div = val_raw & 0xFFFF;
-        printf("gpu_clk_o_2div=0x%04x\n", spll_cfg_customclock.clkO2Div);
-    }
-
-    /*u64 gpu_freq = pll_calc_frequency(&spll_cfg_customclock);
-    u64 gpu_freq_mhz = gpu_freq / 1000000;
-    u64 gpu_freq_remainder = (gpu_freq-(gpu_freq_mhz * 1000000));
-    printf("GPU clocked at: %llu.%lluMHz\n", gpu_freq_mhz, gpu_freq_remainder);*/
-    
-    return 0;
 }

--- a/arm/video/menu.c
+++ b/arm/video/menu.c
@@ -75,6 +75,10 @@ void menu_select(menu_t *menu)
 void menu_init(menu_t *menu)
 {
     menu->state = MENU_REDRAW;
+
+    if (!menu->option[menu->selected].active)
+        menu_next_selection(menu);
+
     while (menu->state != MENU_QUIT)
     {
         menu_draw(menu);

--- a/arm/video/pll.c
+++ b/arm/video/pll.c
@@ -308,7 +308,7 @@ int pll_upll_read(bsp_pll_cfg *pOut)
     if ( (v17 & 0x20000000) != 0
         || (v17 & 0x10000000) != 0
         || (v17 & 0x8000000u) >> 27
-        || (abif_cpl_ct_read32(0x888u) & 0xE000) != 0x4000 && (abif_cpl_ct_read32(0x888u) & 7) != 2 )
+        || ((abif_cpl_ct_read32(0x888u) & 0xE000) != 0x4000 && (abif_cpl_ct_read32(0x888u) & 7) != 2 ))
     {
         return 0;
     }
@@ -353,138 +353,6 @@ void pll_upll_init()
     if (memcmp(&upll_cfg, &cfg, sizeof(bsp_pll_cfg))) {
         pll_upll_write(&upll_cfg);
     }
-}
-
-int pll_syspll_read(bsp_pll_cfg **ppCfg, u32 *pSysClkFreq)
-{
-    bsp_pll_cfg *pCfg = NULL;
-    u32 freq = 0;
-    int result = 0;
-
-    u32 bspVer = latte_get_hw_version();
-    if (!bspVer)
-        return -1;
-
-    if ( (seeprom.bc.library_version) <= 2u )
-    {
-        pCfg = &syspll_243_cfg;
-        freq = 243000000;
-    }
-    else if ( seeprom.bc.sys_pll_speed == 0xF0 )
-    {
-        pCfg = &syspll_240_cfg;
-        freq = 239625000;
-    }
-    else if ( seeprom.bc.sys_pll_speed == 0xF8 )
-    {
-        pCfg = &syspll_248_cfg;
-        freq = 248625000;
-    }
-    else
-    {
-        pCfg = &syspll_243_cfg;
-        freq = 243000000;
-    }
-
-    if ( ppCfg )
-        *ppCfg = pCfg;
-
-    if ( pSysClkFreq )
-        *pSysClkFreq = freq;
-    return result;
-}
-
-int pll_syspll_write(bsp_pll_cfg *pParams)
-{
-    int v1; // lr
-    u16 v3; // r0
-    u16 v4; // r1
-    u16 v5; // r2
-    u16 v6; // r0
-    u16 v7; // r1
-    u16 v8; // r2
-    u16 v9; // r0
-    u16 v10; // r1
-    u16 v11; // r2
-    int v13; // [sp+0h] [bp-2Ch]
-    int v17; // [sp+2Ch] [bp+0h] BYREF
-    u32 bspVer;
-
-    v13 = 0;
-    bspVer = latte_get_hw_version();
-    if ( bspVer && (bspVer & 0xF000000) != 0 )
-    {
-        set32(LT_CLOCKINFO, 1);
-        udelay(10);
-        clear32(LT_RESETS_COMPAT, RSTB_DSKPLL);
-        udelay(10);
-        clear32(LT_RESETS_COMPAT, NLCKB_SYSPLL);
-        udelay(20);
-        clear32(LT_RESETS_COMPAT, RSTB_SYSPLL);
-        abif_cpl_tl_write16(0x20u, pParams->clkR | (pParams->clkO0Div << 6));
-        v3 = pParams->clkFMsb;
-        if (pParams->bypVco)
-            v4 = 0x1000;
-        else
-            v4 = 0;
-        if (pParams->bypOut)
-            v5 = 0x2000;
-        else
-            v5 = 0;
-        abif_cpl_tl_write16(0x22u, v4 | v3 | v5);
-        v6 = pParams->clkO1Div;
-        if (pParams->satEn)
-            v7 = 0x800;
-        else
-            v7 = 0;
-        if (pParams->fastEn)
-            v8 = 0x1000;
-        else
-            v8 = 0;
-        abif_cpl_tl_write16(0x24u, v7 | v6 | v8);
-        abif_cpl_tl_write16(0x26u, pParams->clkFLsb);
-        abif_cpl_tl_write16(0x28u, pParams->clkVLsb);
-        v9 = pParams->clkVMsb;
-        if ( pParams->ssEn)
-            v10 = 0x800;
-        else
-            v10 = 0;
-        if (pParams->dithEn)
-            v11 = 0x1000;
-        else
-            v11 = 0;
-        abif_cpl_tl_write16(0x2Au, v10 | v9 | v11);
-        abif_cpl_tl_write16(0x2Cu, pParams->clkS);
-        abif_cpl_tl_write16(0x2Eu, pParams->bwAdj);
-        clear32(LT_CLOCKINFO, 2);
-        set32(LT_SYSPLL_CFG, pParams->options & 1);
-        udelay(5);
-        set32(LT_RESETS_COMPAT, RSTB_SYSPLL);
-        udelay(200);
-        set32(LT_RESETS_COMPAT, NLCKB_SYSPLL);
-        set32(LT_RESETS_COMPAT, RSTB_DSKPLL);
-        udelay(200);
-        clear32(LT_CLOCKINFO, 1);
-    }
-    return v13;
-}
-
-int pll_syspll_init(int bIdk)
-{
-    int result = 0;
-    bsp_pll_cfg cfg;
-    bsp_pll_cfg *ppCfg;
-
-    ppCfg = 0;
-    result = pll_syspll_read(&ppCfg, 0);
-    if ( !result )
-    {
-        memcpy(&cfg, ppCfg, sizeof(cfg));
-        if ( bIdk )
-            cfg.options |= 1;
-        result = pll_syspll_write(&cfg);
-    }
-    return result;
 }
 
 int pll_spll_write(bsp_pll_cfg *pPllCfg)


### PR DESCRIPTION
This submission fixes an issue where the "Install" option remained selected by default even when inactive (e.g., due to a missing superblock). It also introduces a general safeguard in the menu system to ensure that any menu always starts with an active item selected. Specifically, the main menu now defaults to "Power off" if "Install" is unavailable, preventing accidental selection of the "Uninstall" option.

also some cleanup to fix the build on the latest toolchain