### PR TITLE
Add automated command execution via IPC

### DIFF
--- a/arm/common/isfshax_cmd.h
+++ b/arm/common/isfshax_cmd.h
@@ -1,0 +1,26 @@
+#ifndef ISFSHAX_CMD_H
+#define ISFSHAX_CMD_H
+
+#include "common/types.h"
+
+#define ISFSHAX_CMD_ADDR 0x10008000
+
+#define ISFSHAX_CMD_MAGIC "FSHAXCMD"
+
+#define ISFSHAX_CMD_INSTALL   0x494E5354
+#define ISFSHAX_CMD_UNINSTALL 0x554E494E
+
+#define ISFSHAX_CMD_SOURCE_SD   0
+#define ISFSHAX_CMD_SOURCE_SLC  1
+
+#define ISFSHAX_CMD_POST_NOTHING   0
+#define ISFSHAX_CMD_POST_REBOOT    1
+#define ISFSHAX_CMD_POST_POWEROFF  2
+
+typedef struct {
+    char magic[8];
+    u32 command;
+    u32 parameter;
+} isfshax_cmd;
+
+#endif

--- a/arm/common/isfshax_cmd.h
+++ b/arm/common/isfshax_cmd.h
@@ -3,7 +3,7 @@
 
 #include "common/types.h"
 
-#define ISFSHAX_CMD_ADDR 0x10008000
+#define ISFSHAX_CMD_ADDR 0xFFFFFF00
 
 #define ISFSHAX_CMD_MAGIC "FSHAXCMD"
 

--- a/arm/common/utils.c
+++ b/arm/common/utils.c
@@ -13,10 +13,12 @@
 #include "types.h"
 #include "utils.h"
 #include "video/gfx.h"
+#include "video/console.h"
 #include "system/gpio.h"
 #include "system/latte.h"
 
 #include <stdarg.h>
+#include <stdio.h>
 
 #if defined(CAN_HAZ_USBGECKO) && !defined(LOADER) && !defined(NDEBUG)
 static char ascii(char s) {
@@ -76,4 +78,13 @@ void panic(u8 v)
         //clear32(HW_GPIO1BOUT, GP_SLOTLED);
         //udelay(500000);
     }
+}
+
+void pr_error(const char *fmt, ...) {
+    va_list va;
+    va_start(va, fmt);
+    fputs(CONSOLE_RED "ERROR: ", stdout);
+    vprintf(fmt, va);
+    fputs(CONSOLE_RESET, stdout);
+    va_end(va);
 }

--- a/arm/common/utils.h
+++ b/arm/common/utils.h
@@ -11,6 +11,7 @@
 #define __UTILS_H__
 
 #include "types.h"
+#include <stdarg.h>
 
 static inline ALWAYS_INLINE u32 read32(u32 addr)
 {
@@ -185,6 +186,7 @@ void memcpy8(void *dst, void *src, u32 size);
 void hexdump(const void *d, int len);
 void udelay(u32 d);
 void panic(u8 v);
+void pr_error(const char *fmt, ...);
 
 static inline ALWAYS_INLINE u32 get_cpsr(void)
 {

--- a/arm/gui.c
+++ b/arm/gui.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <malloc.h>
+#include <string.h>
 #include "video/gfx.h"
 #include "system/exception.h"
 #include "system/memory.h"
@@ -10,6 +11,7 @@
 #include "crypto/crypto.h"
 #include "system/smc.h"
 #include "common/utils.h"
+#include "common/isfshax_cmd.h"
 #include "gui.h"
 #include "installer.h"
 #include "video/menu.h"
@@ -38,25 +40,78 @@ static menu_t m_main = {
 
 void gui_main() {
     int status = 0;
+    bool skip_disclaimer = false;
+    isfshax_cmd *cmd = (isfshax_cmd *)ISFSHAX_CMD_ADDR;
+
     puts("\e[H\e[J\e[36misfshax\e[0m installer");
     puts("\b\e[19D(c) 2021 rw-r-r-0644\n");
 
-    /* disclaimer */
-    puts(
-        "THIS SOFTWARE COMES WITH ABSOLUTELY NO WARRANTY! YOU ARE\n"
-        "CHOOSING TO INSTALL THIS SOFTWARE, AT YOUR OWN RISK.\n"
-        "THE AUTHOR(S) OF THIS SOFTWARE WILL NOT BE HELD LIABLE\n"
-        "FOR ANY DAMAGE IT MIGHT CAUSE.\n\n"
-        "THIS SOFTWARE IS AVAILABLE FOR FREE UNDER THE TERMS OF THE\n"
-        "GNU GPLv2 LICENSE. IF YOU'VE PAID FOR THIS SOFTWARE, YOU\n"
-        "HAVE BEEN SCAMMED AND SHOULD ASK FOR YOUR MONEY BACK.\n"
-    );
-    wait_continue();
+    if (memcmp(cmd->magic, ISFSHAX_CMD_MAGIC, 8) == 0) {
+        u32 command = cmd->command;
+        u32 parameter = cmd->parameter;
+        memset(cmd->magic, 0, 8);
 
-    /* check isfshax compatibility */
-    puts("\e[2;0H\e[0J\e[33mCompatibility check\e[0m");
-    status = installer_check_compatibility();
-    wait_continue();
+        int source = parameter & 0xFF;
+        int post_action = (parameter >> 30) & 0x3;
+
+        installer_set_source(source);
+
+        puts("\e[2;0H\e[0J\e[33mAutomated Command Execution\e[0m");
+        status = installer_check_compatibility();
+
+        int rc = -1;
+        if (command == ISFSHAX_CMD_INSTALL) {
+            if (status & ISFSHAX_INSTALL_POSSIBLE) {
+                rc = install_isfshax();
+            } else {
+                pr_error("Install not possible!\n");
+            }
+        } else if (command == ISFSHAX_CMD_UNINSTALL) {
+            if (status & ISFSHAX_REMOVAL_POSSIBLE) {
+                rc = uninstall_isfshax();
+            } else {
+                pr_error("Uninstall not possible!\n");
+            }
+        } else {
+            pr_error("Unknown command 0x%08X\n", command);
+        }
+
+        if (rc >= 0) {
+            skip_disclaimer = true;
+            if (post_action == ISFSHAX_CMD_POST_REBOOT) {
+                puts("Rebooting...");
+                udelay(2000000);
+                smc_shutdown(true);
+            } else if (post_action == ISFSHAX_CMD_POST_POWEROFF) {
+                puts("Powering off...");
+                udelay(2000000);
+                smc_shutdown(false);
+            }
+            // Refresh status for the menu
+            status = installer_check_compatibility();
+        }
+        installer_set_source(-1);
+        wait_continue();
+    }
+
+    if (!skip_disclaimer) {
+        /* disclaimer */
+        puts(
+            "THIS SOFTWARE COMES WITH ABSOLUTELY NO WARRANTY! YOU ARE\n"
+            "CHOOSING TO INSTALL THIS SOFTWARE, AT YOUR OWN RISK.\n"
+            "THE AUTHOR(S) OF THIS SOFTWARE WILL NOT BE HELD LIABLE\n"
+            "FOR ANY DAMAGE IT MIGHT CAUSE.\n\n"
+            "THIS SOFTWARE IS AVAILABLE FOR FREE UNDER THE TERMS OF THE\n"
+            "GNU GPLv2 LICENSE. IF YOU'VE PAID FOR THIS SOFTWARE, YOU\n"
+            "HAVE BEEN SCAMMED AND SHOULD ASK FOR YOUR MONEY BACK.\n"
+        );
+        wait_continue();
+
+        /* check isfshax compatibility */
+        puts("\e[2;0H\e[0J\e[33mCompatibility check\e[0m");
+        status = installer_check_compatibility();
+        wait_continue();
+    }
 
     /* update main menu accordingly */
     m_main.option[0].active = (status & ISFSHAX_INSTALL_POSSIBLE) != 0;

--- a/arm/gui.c
+++ b/arm/gui.c
@@ -26,7 +26,7 @@ static int ask_confirmation(void);
 static void wait_continue(void);
 
 static menu_t m_main = {
-    .title = "\e[2;0H\e[0J\e[33mMain menu\e[0m",
+    .title = "\e[11;0H\e[0J\e[33mMain menu\e[0m",
     .option = {
         {"Install isfshax", &main_install, 0},
         {"Uninstall isfshax", &main_uninstall, 0},
@@ -40,11 +40,21 @@ static menu_t m_main = {
 
 void gui_main() {
     int status = 0;
-    bool skip_disclaimer = false;
     isfshax_cmd *cmd = (isfshax_cmd *)ISFSHAX_CMD_ADDR;
 
     puts("\e[H\e[J\e[36misfshax\e[0m installer");
     puts("\b\e[19D(c) 2021 rw-r-r-0644\n");
+
+    /* disclaimer */
+    puts(
+        "THIS SOFTWARE COMES WITH ABSOLUTELY NO WARRANTY! YOU ARE\n"
+        "CHOOSING TO INSTALL THIS SOFTWARE, AT YOUR OWN RISK.\n"
+        "THE AUTHOR(S) OF THIS SOFTWARE WILL NOT BE HELD LIABLE\n"
+        "FOR ANY DAMAGE IT MIGHT CAUSE.\n\n"
+        "THIS SOFTWARE IS AVAILABLE FOR FREE UNDER THE TERMS OF THE\n"
+        "GNU GPLv2 LICENSE. IF YOU'VE PAID FOR THIS SOFTWARE, YOU\n"
+        "HAVE BEEN SCAMMED AND SHOULD ASK FOR YOUR MONEY BACK.\n"
+    );
 
     if (memcmp(cmd->magic, ISFSHAX_CMD_MAGIC, 8) == 0) {
         u32 command = cmd->command;
@@ -56,7 +66,7 @@ void gui_main() {
 
         installer_set_source(source);
 
-        puts("\e[2;0H\e[0J\e[33mAutomated Command Execution\e[0m");
+        puts("\e[11;0H\e[0J\e[33mAutomated Command Execution\e[0m");
         status = installer_check_compatibility();
 
         int rc = -1;
@@ -77,7 +87,6 @@ void gui_main() {
         }
 
         if (rc >= 0) {
-            skip_disclaimer = true;
             if (post_action == ISFSHAX_CMD_POST_REBOOT) {
                 puts("Rebooting...");
                 udelay(2000000);
@@ -92,23 +101,11 @@ void gui_main() {
         }
         installer_set_source(-1);
         wait_continue();
-    }
-
-    if (!skip_disclaimer) {
-        /* disclaimer */
-        puts(
-            "THIS SOFTWARE COMES WITH ABSOLUTELY NO WARRANTY! YOU ARE\n"
-            "CHOOSING TO INSTALL THIS SOFTWARE, AT YOUR OWN RISK.\n"
-            "THE AUTHOR(S) OF THIS SOFTWARE WILL NOT BE HELD LIABLE\n"
-            "FOR ANY DAMAGE IT MIGHT CAUSE.\n\n"
-            "THIS SOFTWARE IS AVAILABLE FOR FREE UNDER THE TERMS OF THE\n"
-            "GNU GPLv2 LICENSE. IF YOU'VE PAID FOR THIS SOFTWARE, YOU\n"
-            "HAVE BEEN SCAMMED AND SHOULD ASK FOR YOUR MONEY BACK.\n"
-        );
+    } else {
         wait_continue();
 
         /* check isfshax compatibility */
-        puts("\e[2;0H\e[0J\e[33mCompatibility check\e[0m");
+        puts("\e[11;0H\e[0J\e[33mCompatibility check\e[0m");
         status = installer_check_compatibility();
         wait_continue();
     }
@@ -127,10 +124,10 @@ void gui_main() {
 static void main_install(menu_t *menu) {
     int rc;
 
-    puts("\e[2;0H\e[0JInstall isfshax now?");
+    puts("\e[11;0H\e[0JInstall isfshax now?");
     if (!ask_confirmation()) return;
 
-    puts("\e[2;0H\e[0JInstalling isfshax...");
+    puts("\e[11;0H\e[0JInstalling isfshax...");
     rc = install_isfshax();
 
     if (rc >= 0) {
@@ -144,13 +141,13 @@ static void main_install(menu_t *menu) {
 static void main_uninstall(menu_t *menu) {
     int rc;
 
-    puts("\e[2;0H\e[0J" CONSOLE_RED "WARNING: Before Uninstalling ISFShax make sure the console boots correctly using\n"
+    puts("\e[11;0H\e[0J" CONSOLE_RED "WARNING: Before Uninstalling ISFShax make sure the console boots correctly using\n"
         "the 'Patch ISFShax and boot IOS (slc)' option in minute\n"
         "If your console can't boot correctly, uninstalling ISFShax will BRICK the console!!!" CONSOLE_RESET "\n\n"
         "Uninstall isfshax now?");
     if (!ask_confirmation()) return;
 
-    puts("\e[2;0H\e[0J" "Uninstalling isfshax...");
+    puts("\e[11;0H\e[0J" "Uninstalling isfshax...");
     rc = uninstall_isfshax();
 
     if (rc >= 0) {
@@ -163,7 +160,7 @@ static void main_uninstall(menu_t *menu) {
 
 static void main_credits(menu_t *menu) {
     puts(
-        "\e[2;0H\e[0JThanks to:\n\n"
+        "\e[11;0H\e[0JThanks to:\n\n"
         "rw-r-r-0644,\t\tMaschell,\t\tQuarkTheAwesome,\n"
         "GaryOderNichts,\t\texjam,\t\t\tvgmoose,\n"
         "CompuCat,\t\t\thexkyz,\t\t\tderrek,\n"

--- a/arm/gui.c
+++ b/arm/gui.c
@@ -22,6 +22,7 @@ static void main_install(menu_t *menu);
 static void main_uninstall(menu_t *menu);
 static void main_credits(menu_t *menu);
 
+static int gui_handle_automated_cmd(int *status);
 static int ask_confirmation(void);
 static void wait_continue(void);
 
@@ -57,50 +58,7 @@ void gui_main() {
     );
 
     if (memcmp(cmd->magic, ISFSHAX_CMD_MAGIC, 8) == 0) {
-        u32 command = cmd->command;
-        u32 parameter = cmd->parameter;
-        memset(cmd->magic, 0, 8);
-
-        int source = parameter & 0xFF;
-        int post_action = (parameter >> 30) & 0x3;
-
-        installer_set_source(source);
-
-        puts("\e[11;0H\e[0J\e[33mAutomated Command Execution\e[0m");
-        status = installer_check_compatibility();
-
-        int rc = -1;
-        if (command == ISFSHAX_CMD_INSTALL) {
-            if (status & ISFSHAX_INSTALL_POSSIBLE) {
-                rc = install_isfshax();
-            } else {
-                pr_error("Install not possible!\n");
-            }
-        } else if (command == ISFSHAX_CMD_UNINSTALL) {
-            if (status & ISFSHAX_REMOVAL_POSSIBLE) {
-                rc = uninstall_isfshax();
-            } else {
-                pr_error("Uninstall not possible!\n");
-            }
-        } else {
-            pr_error("Unknown command 0x%08X\n", command);
-        }
-
-        if (rc >= 0) {
-            if (post_action == ISFSHAX_CMD_POST_REBOOT) {
-                puts("Rebooting...");
-                udelay(2000000);
-                smc_shutdown(true);
-            } else if (post_action == ISFSHAX_CMD_POST_POWEROFF) {
-                puts("Powering off...");
-                udelay(2000000);
-                smc_shutdown(false);
-            }
-            // Refresh status for the menu
-            status = installer_check_compatibility();
-        }
-        installer_set_source(-1);
-        wait_continue();
+        gui_handle_automated_cmd(&status);
     } else {
         wait_continue();
 
@@ -156,6 +114,56 @@ static void main_uninstall(menu_t *menu) {
     }
 
     wait_continue();
+}
+
+static int gui_handle_automated_cmd(int *status) {
+    isfshax_cmd *cmd = (isfshax_cmd *)ISFSHAX_CMD_ADDR;
+    u32 command = cmd->command;
+    u32 parameter = cmd->parameter;
+    memset(cmd->magic, 0, 8);
+
+    int source = parameter & 0xFF;
+    int post_action = (parameter >> 30) & 0x3;
+
+    installer_set_source(source);
+
+    puts("\e[11;0H\e[0J\e[33mAutomated Command Execution\e[0m");
+    *status = installer_check_compatibility();
+
+    int rc = -1;
+    if (command == ISFSHAX_CMD_INSTALL) {
+        if (*status & ISFSHAX_INSTALL_POSSIBLE) {
+            rc = install_isfshax();
+        } else {
+            pr_error("Install not possible!\n");
+        }
+    } else if (command == ISFSHAX_CMD_UNINSTALL) {
+        if (*status & ISFSHAX_REMOVAL_POSSIBLE) {
+            rc = uninstall_isfshax();
+        } else {
+            pr_error("Uninstall not possible!\n");
+        }
+    } else {
+        pr_error("Unknown command 0x%08X\n", command);
+    }
+
+    if (rc >= 0) {
+        if (post_action == ISFSHAX_CMD_POST_REBOOT) {
+            puts("Rebooting...");
+            udelay(2000000);
+            smc_shutdown(true);
+        } else if (post_action == ISFSHAX_CMD_POST_POWEROFF) {
+            puts("Powering off...");
+            udelay(2000000);
+            smc_shutdown(false);
+        }
+        // Refresh status for the menu
+        *status = installer_check_compatibility();
+    }
+    installer_set_source(-1);
+    wait_continue();
+
+    return rc;
 }
 
 static void main_credits(menu_t *menu) {

--- a/arm/installer.c
+++ b/arm/installer.c
@@ -31,6 +31,7 @@ static isfshax_super s_superblock_buf;
 static int s_forced_source = -1;
 
 static void installer_check_superblock(void);
+static int _check_superblock_source(const char *img_path, const char *sha_path, superblock_state state);
 static int _load_file_from_sd(const char *path, void *buf, u32 size);
 static int _load_file_from_slc(const char *path, void *buf, u32 size);
 
@@ -283,43 +284,52 @@ int uninstall_isfshax(void)
     return 0;
 }
 
-static void installer_check_superblock(void)
+static int _check_superblock_source(const char *img_path, const char *sha_path, superblock_state state)
 {
     u8 savedhash[SHA_HASH_SIZE], computedhash[SHA_HASH_SIZE];
     int error;
 
+    if (state == SUPERBLOCK_FROM_SD)
+        error = _load_file_from_sd(img_path, &s_superblock_buf, sizeof(s_superblock_buf));
+    else
+        error = _load_file_from_slc(img_path, &s_superblock_buf, sizeof(s_superblock_buf));
+
+    if (error == 0) {
+        if (state == SUPERBLOCK_FROM_SD)
+            error = _load_file_from_sd(sha_path, savedhash, sizeof(savedhash));
+        else
+            error = _load_file_from_slc(sha_path, savedhash, sizeof(savedhash));
+
+        if (error == 0) {
+            sha_hash(&s_superblock_buf, computedhash, sizeof(s_superblock_buf));
+            if (memcmp(savedhash, computedhash, SHA_HASH_SIZE) == 0) {
+                s_superblock_state = state;
+                return 0;
+            }
+            s_superblock_state = SUPERBLOCK_INVALID_CHECKSUM;
+            return -3;
+        }
+        return -1;
+    } else if (error == -2) {
+        s_superblock_state = SUPERBLOCK_INVALID_SIZE;
+        return -2;
+    }
+
+    return -1;
+}
+
+static void installer_check_superblock(void)
+{
     s_superblock_state = SUPERBLOCK_NOT_FOUND;
 
     if (s_forced_source == -1 || s_forced_source == ISFSHAX_CMD_SOURCE_SD) {
-        if ((error = _load_file_from_sd("superblock.img", &s_superblock_buf, sizeof(s_superblock_buf))) == 0) {
-            if (_load_file_from_sd("superblock.img.sha", savedhash, sizeof(savedhash)) == 0) {
-                s_superblock_state = SUPERBLOCK_FROM_SD;
-            } else {
-                s_superblock_state = SUPERBLOCK_NOT_FOUND;
-            }
-        } else if (error == -2) {
-            s_superblock_state = SUPERBLOCK_INVALID_SIZE;
-        }
+        if (_check_superblock_source("superblock.img", "superblock.img.sha", SUPERBLOCK_FROM_SD) == 0)
+            return;
     }
 
-    if (s_superblock_state == SUPERBLOCK_NOT_FOUND && (s_forced_source == -1 || s_forced_source == ISFSHAX_CMD_SOURCE_SLC)) {
-        if ((error = _load_file_from_slc("slc:/sys/hax/installer/sblock.img", &s_superblock_buf, sizeof(s_superblock_buf))) == 0) {
-            if (_load_file_from_slc("slc:/sys/hax/installer/sblock.sha", savedhash, sizeof(savedhash)) == 0) {
-                s_superblock_state = SUPERBLOCK_FROM_SLC;
-            } else {
-                s_superblock_state = SUPERBLOCK_NOT_FOUND;
-            }
-        } else if (error == -2) {
-            s_superblock_state = SUPERBLOCK_INVALID_SIZE;
-        }
+    if (s_superblock_state != SUPERBLOCK_INVALID_SIZE && (s_forced_source == -1 || s_forced_source == ISFSHAX_CMD_SOURCE_SLC)) {
+        _check_superblock_source("slc:/sys/hax/installer/sblock.img", "slc:/sys/hax/installer/sblock.sha", SUPERBLOCK_FROM_SLC);
     }
-
-    if ((s_superblock_state != SUPERBLOCK_FROM_SD) && (s_superblock_state != SUPERBLOCK_FROM_SLC))
-        return;
-
-    sha_hash(&s_superblock_buf, computedhash, sizeof(s_superblock_buf));
-    if (memcmp(savedhash, computedhash, SHA_HASH_SIZE))
-        s_superblock_state = SUPERBLOCK_INVALID_CHECKSUM;
 }
 
 static int _load_file_from_sd(const char *path, void *buf, u32 size)

--- a/arm/installer.c
+++ b/arm/installer.c
@@ -319,10 +319,7 @@ static void installer_check_superblock(void)
             return;
     }
 
-    if (s_superblock_state == SUPERBLOCK_INVALID_SIZE)
-        return;
-
-    if (s_forced_source == -1 || s_forced_source == ISFSHAX_CMD_SOURCE_SLC) {
+    if ((s_superblock_state == SUPERBLOCK_NOT_FOUND && s_forced_source == -1) || s_forced_source == ISFSHAX_CMD_SOURCE_SLC) {
         _check_superblock_source("slc:/sys/hax/installer/sblock.img", "slc:/sys/hax/installer/sblock.sha", SUPERBLOCK_FROM_SLC);
     }
 }

--- a/arm/installer.c
+++ b/arm/installer.c
@@ -41,14 +41,6 @@ void installer_set_source(int source)
     s_forced_source = source;
 }
 
-void pr_error(const char *fmt, ...) {
-    va_list va;
-    va_start(va, fmt);
-    fputs(CONSOLE_RED "ERROR: ", stdout);
-    vprintf(fmt, va);
-    fputs(CONSOLE_RESET, stdout);
-    va_end(va);
-}
 
 int installer_check_compatibility(void)
 {

--- a/arm/installer.c
+++ b/arm/installer.c
@@ -327,7 +327,10 @@ static void installer_check_superblock(void)
             return;
     }
 
-    if (s_superblock_state != SUPERBLOCK_INVALID_SIZE && (s_forced_source == -1 || s_forced_source == ISFSHAX_CMD_SOURCE_SLC)) {
+    if (s_superblock_state == SUPERBLOCK_INVALID_SIZE)
+        return;
+
+    if (s_forced_source == -1 || s_forced_source == ISFSHAX_CMD_SOURCE_SLC) {
         _check_superblock_source("slc:/sys/hax/installer/sblock.img", "slc:/sys/hax/installer/sblock.sha", SUPERBLOCK_FROM_SLC);
     }
 }

--- a/arm/installer.c
+++ b/arm/installer.c
@@ -24,14 +24,21 @@
 #include "video/console.h"
 #include "installer.h"
 #include "boot1.h"
+#include "common/isfshax_cmd.h"
 
 superblock_state s_superblock_state = SUPERBLOCK_NOT_CHECKED;
 static isfshax_super s_superblock_buf;
+static int s_forced_source = -1;
 
 static void installer_check_superblock(void);
 static int _load_file_from_sd(const char *path, void *buf, u32 size);
 static int _load_file_from_slc(const char *path, void *buf, u32 size);
 
+
+void installer_set_source(int source)
+{
+    s_forced_source = source;
+}
 
 void pr_error(const char *fmt, ...) {
     va_list va;
@@ -281,26 +288,31 @@ static void installer_check_superblock(void)
     u8 savedhash[SHA_HASH_SIZE], computedhash[SHA_HASH_SIZE];
     int error;
 
-    if ((error = _load_file_from_sd("superblock.img", &s_superblock_buf, sizeof(s_superblock_buf)))) {
-        if (error == -2)
-            s_superblock_state = SUPERBLOCK_INVALID_SIZE;
-        else
-            s_superblock_state = SUPERBLOCK_NOT_FOUND;
-    } else if (_load_file_from_sd("superblock.img.sha", savedhash, sizeof(savedhash)))
-        s_superblock_state = SUPERBLOCK_NOT_FOUND;
-    else
-        s_superblock_state = SUPERBLOCK_FROM_SD;
+    s_superblock_state = SUPERBLOCK_NOT_FOUND;
 
-    if (s_superblock_state == SUPERBLOCK_NOT_FOUND) {
-        if ((error = _load_file_from_slc("slc:/sys/hax/installer/sblock.img", &s_superblock_buf, sizeof(s_superblock_buf)))) {
-            if (error == -2)
-                s_superblock_state = SUPERBLOCK_INVALID_SIZE;
-        } else if (_load_file_from_slc("slc:/sys/hax/installer/sblock.sha", savedhash, sizeof(savedhash)))
-            s_superblock_state = SUPERBLOCK_NOT_FOUND;
-        else
-            s_superblock_state = SUPERBLOCK_FROM_SLC;
+    if (s_forced_source == -1 || s_forced_source == ISFSHAX_CMD_SOURCE_SD) {
+        if ((error = _load_file_from_sd("superblock.img", &s_superblock_buf, sizeof(s_superblock_buf))) == 0) {
+            if (_load_file_from_sd("superblock.img.sha", savedhash, sizeof(savedhash)) == 0) {
+                s_superblock_state = SUPERBLOCK_FROM_SD;
+            } else {
+                s_superblock_state = SUPERBLOCK_NOT_FOUND;
+            }
+        } else if (error == -2) {
+            s_superblock_state = SUPERBLOCK_INVALID_SIZE;
+        }
     }
 
+    if (s_superblock_state == SUPERBLOCK_NOT_FOUND && (s_forced_source == -1 || s_forced_source == ISFSHAX_CMD_SOURCE_SLC)) {
+        if ((error = _load_file_from_slc("slc:/sys/hax/installer/sblock.img", &s_superblock_buf, sizeof(s_superblock_buf))) == 0) {
+            if (_load_file_from_slc("slc:/sys/hax/installer/sblock.sha", savedhash, sizeof(savedhash)) == 0) {
+                s_superblock_state = SUPERBLOCK_FROM_SLC;
+            } else {
+                s_superblock_state = SUPERBLOCK_NOT_FOUND;
+            }
+        } else if (error == -2) {
+            s_superblock_state = SUPERBLOCK_INVALID_SIZE;
+        }
+    }
 
     if ((s_superblock_state != SUPERBLOCK_FROM_SD) && (s_superblock_state != SUPERBLOCK_FROM_SLC))
         return;

--- a/arm/installer.h
+++ b/arm/installer.h
@@ -23,6 +23,7 @@ typedef enum {
 
 extern superblock_state s_superblock_state;
 
+void installer_set_source(int source);
 int installer_check_compatibility(void);
 
 int install_isfshax(void);

--- a/stub.ld
+++ b/stub.ld
@@ -20,6 +20,7 @@ __excstack_size = 0x40000;
 MEMORY {
 	sram0		: ORIGIN = 0xffff0000, LENGTH = 64K
 	mem2		: ORIGIN = 0x10100000, LENGTH = 60M
+	params  	: ORIGIN = 0xFFFFFF00, LENGTH = 256
 }
 
 SECTIONS
@@ -96,6 +97,11 @@ SECTIONS
 		__heap_end__ = (ORIGIN(mem2) + LENGTH(mem2));
 		. = __heap_end__;
 	} >mem2
+
+	.params :
+	{
+		*(.params)
+	} >params
 
 	/DISCARD/ :
 	{


### PR DESCRIPTION
This change adds support for automated installation and uninstallation via memory-mapped IPC.
The installer checks for the magic string "FSHAXCMD" at 0x10008000.
If found, it reads the command (Install/Uninstall) and parameters (Source, Post-Action).
It then performs the action without user intervention, and optionally reboots or powers off the console.

---
*PR created automatically by Jules for task [18304710953317409262](https://jules.google.com/task/18304710953317409262) started by @jan-hofmeier*